### PR TITLE
add circom just

### DIFF
--- a/circom/README.md
+++ b/circom/README.md
@@ -150,3 +150,17 @@ Export the verification key:
 % snarkjs groth16 verify verification_key.json input.json proof.json
 [INFO]  snarkJS: OK!
 ```
+
+## Predefined commands
+
+Alternatively you can run predefined commands to simplify process described above.
+Commands are defined in `justfile`
+In order to be able to run them you need to install `just` command runner, see https://github.com/casey/just#installation
+
+For example to build circuits just type `just build`
+
+In order to perform full tau ceremony just type `just tau`
+
+In order to generate proof just type `just generate-proof`
+
+In order to verify proof just type `just verify-proof`

--- a/circom/justfile
+++ b/circom/justfile
@@ -48,3 +48,6 @@ generate-proof:
 #verify proof
 verify-proof:
 	cd build && snarkjs groth16 verify verification_key.json input.json proof.json
+
+all:
+  just build && just tau && just generate-proof && just verify-proof

--- a/circom/justfile
+++ b/circom/justfile
@@ -2,6 +2,9 @@
 build:
 	just compile-circuit && just compute-witness
 
+go-to-build:
+  cd build
+
 #compile circuit
 compile-circuit:
 	circom task.circom --r1cs --wasm --sym -o build --O0 -p bls12381
@@ -16,32 +19,32 @@ tau:
 
 #create ceremony
 tau-create-ceremony:
-	snarkjs powersoftau new bls12381 12 pot12_0000.ptau -v
+	cd build && snarkjs powersoftau new bls12381 12 pot12_0000.ptau -v
 
 #make first contribution
 tau-first-contribution:
-	snarkjs powersoftau contribute pot12_0000.ptau pot12_0001.ptau --name="ZkSnarks phase #1" -v
+	cd build && snarkjs powersoftau contribute pot12_0000.ptau pot12_0001.ptau --name="ZkSnarks phase #1" -v
 
 #start phase 2
 tau-phase-2:
-	snarkjs powersoftau prepare phase2 pot12_0001.ptau pot12_final.ptau -v
+	cd build && snarkjs powersoftau prepare phase2 pot12_0001.ptau pot12_final.ptau -v
 
 #generate z-key
 tau-z-key:
-	snarkjs groth16 setup build/task.r1cs pot12_final.ptau task_0000.zkey
+	cd build && snarkjs groth16 setup task.r1cs pot12_final.ptau task_0000.zkey
 
 #make second contribution
 tau-second-contribution:
-	snarkjs zkey contribute task_0000.zkey task_0001.zkey --name="ZkSnarks phase #2" -v
+	cd build && snarkjs zkey contribute task_0000.zkey task_0001.zkey --name="ZkSnarks phase #2" -v
 
 #export verification-key
 tau-export-vk:
-	snarkjs zkey export verificationkey task_0001.zkey verification_key.json -v
+	cd build && snarkjs zkey export verificationkey task_0001.zkey verification_key.json -v
 
 #generate proof
 generate-proof:
-	snarkjs groth16 prove task_0001.zkey build/task_js/witness.wtns proof.json input.json
+	cd build && snarkjs groth16 prove task_0001.zkey task_js/witness.wtns proof.json input.json
 
 #verify proof
 verify-proof:
-	snarkjs groth16 verify verification_key.json input.json proof.json
+	cd build && snarkjs groth16 verify verification_key.json input.json proof.json

--- a/circom/justfile
+++ b/circom/justfile
@@ -1,0 +1,47 @@
+#performs build step
+build:
+	just compile-circuit && just compute-witness
+
+#compile circuit
+compile-circuit:
+	circom task.circom --r1cs --wasm --sym -o build --O0 -p bls12381
+
+#compute witness
+compute-witness:
+	cd build/task_js && node generate_witness.js task.wasm ../../input.json witness.wtns
+
+#performs powers of tau step
+tau:
+	just tau-create-ceremony && just tau-first-contribution && just tau-phase-2 && just tau-z-key && just tau-second-contribution && just tau-export-vk
+
+#create ceremony
+tau-create-ceremony:
+	snarkjs powersoftau new bls12381 12 pot12_0000.ptau -v
+
+#make first contribution
+tau-first-contribution:
+	snarkjs powersoftau contribute pot12_0000.ptau pot12_0001.ptau --name="ZkSnarks phase #1" -v
+
+#start phase 2
+tau-phase-2:
+	snarkjs powersoftau prepare phase2 pot12_0001.ptau pot12_final.ptau -v
+
+#generate z-key
+tau-z-key:
+	snarkjs groth16 setup build/task.r1cs pot12_final.ptau task_0000.zkey
+
+#make second contribution
+tau-second-contribution:
+	snarkjs zkey contribute task_0000.zkey task_0001.zkey --name="ZkSnarks phase #2" -v
+
+#export verification-key
+tau-export-vk:
+	snarkjs zkey export verificationkey task_0001.zkey verification_key.json -v
+
+#generate proof
+generate-proof:
+	snarkjs groth16 prove task_0001.zkey build/task_js/witness.wtns proof.json input.json
+
+#verify proof
+verify-proof:
+	snarkjs groth16 verify verification_key.json input.json proof.json


### PR DESCRIPTION
You can install just by `cargo install just`.
Looks like a very handy tool to organise these commands. For example you can run whole tau ceremony just by typing `just tau` 